### PR TITLE
domain used for cookie - an issue in the example

### DIFF
--- a/config.template.yml
+++ b/config.template.yml
@@ -72,7 +72,7 @@ access_control:
 session:
   secret: unsecure_secret
   expiration: 3600000
-  domain: example.com
+  domain: test.local
 
 
 # The directory where the DB files will be saved


### PR DESCRIPTION
Fortunately the discussion in issue #14 helped me figure this out.  Eventually... :-).

Could not get the buttons to register for TOTP or U2F.  Kept getting a message that "the email could not be sent" - which I thought indicated an issue with the file-based notification. 
 
Could get the notification.txt when doing a password change, so dug deeper.  Added and ran tcpdump on the authelia_auth instance, and was seeing the 403 error for all calls - and noticed the domain for the cookie...

Ran into two different issues while verifying this - I think credential may be cached so that log-out doesn't work, and saw some occasional odd connection problems with the ldap server.  But tested enough to determine that those do not seem related to this change.

Thanks, and Best Regards,
Paul