### PR TITLE
Add Content-Length header to the forwarded request to Authelia

### DIFF
--- a/example/nginx/nginx.conf
+++ b/example/nginx/nginx.conf
@@ -65,6 +65,7 @@ http {
             proxy_set_header  X-Original-URI $request_uri;
             proxy_set_header  X-Real-IP $remote_addr;
             proxy_set_header  Host $http_host;
+            proxy_set_header  Content-Length "";
 
             proxy_pass        http://authelia/verify;
         }


### PR DESCRIPTION
It seems nginx is closing the connection for some backends if
`proxy_set_header Content-Length "";` is not added to the
verification endpoint.