### PR TITLE
Add {dn} as an available matcher in LDAP groups filter

### DIFF
--- a/config.template.yml
+++ b/config.template.yml
@@ -33,8 +33,9 @@ ldap:
 
   # The groups filter used for retrieving groups of a given user.
   # {0} is a matcher replaced by username.
-  # 'member=cn={0},<additional_users_dn>,<base_dn>' by default.
-  groups_filter: (&(member=cn={0},ou=users,dc=example,dc=com)(objectclass=groupOfNames))
+  # {dn} is a matcher replaced by user DN.
+  # 'member={dn}' by default.
+  groups_filter: (&(member={dn})(objectclass=groupOfNames))
 
   # The attribute holding the name of the group
   group_name_attribute: cn

--- a/config.test.yml
+++ b/config.test.yml
@@ -33,8 +33,9 @@ ldap:
 
   # The groups filter used for retrieving groups of a given user.
   # {0} is a matcher replaced by username.
-  # 'member=cn={0},<additional_users_dn>,<base_dn>' by default.
-  groups_filter: (&(member=cn={0},ou=users,dc=example,dc=com)(objectclass=groupOfNames))
+  # {dn} is a matcher replaced by user DN.
+  # 'member={dn}' by default.
+  groups_filter: (&(member={dn})(objectclass=groupOfNames))
 
   # The attribute holding the name of the group
   group_name_attribute: cn

--- a/server/src/lib/configuration/ConfigurationParser.ts
+++ b/server/src/lib/configuration/ConfigurationParser.ts
@@ -29,10 +29,7 @@ function ensure_key_existence(config: object, path: string): void {
 
 function adaptLdapConfiguration(userConfig: UserLdapConfiguration): LdapConfiguration {
   const DEFAULT_USERS_FILTER = "cn={0}";
-  const DEFAULT_GROUPS_FILTER =
-    userConfig.additional_users_dn
-      ? Util.format("member=cn={0},%s,%s", userConfig.additional_groups_dn, userConfig.base_dn)
-      : Util.format("member=cn={0},%s", userConfig.base_dn);
+  const DEFAULT_GROUPS_FILTER = "member={dn}";
   const DEFAULT_GROUP_NAME_ATTRIBUTE = "cn";
   const DEFAULT_MAIL_ATTRIBUTE = "mail";
 

--- a/server/src/lib/routes/verify/get.ts
+++ b/server/src/lib/routes/verify/get.ts
@@ -45,7 +45,7 @@ function verify_filter(req: express.Request, res: express.Response): BluebirdPro
 
       const isAllowed = accessController.isAccessAllowed(domain, path, username, groups);
       if (!isAllowed) return BluebirdPromise.reject(
-        new exceptions.DomainAccessDenied(Util.format("User '%s' does not have access to '%'",
+        new exceptions.DomainAccessDenied(Util.format("User '%s' does not have access to '%s'",
           username, domain)));
 
       if (authenticationMethod == "two_factor" && !authSession.second_factor)

--- a/server/test/configuration/LdapConfigurationAdaptation.test.ts
+++ b/server/test/configuration/LdapConfigurationAdaptation.test.ts
@@ -56,7 +56,7 @@ describe("test ldap configuration adaptation", function () {
       users_dn: "dc=example,dc=com",
       users_filter: "cn={0}",
       groups_dn: "dc=example,dc=com",
-      groups_filter: "member=cn={0},dc=example,dc=com",
+      groups_filter: "member={dn}",
       group_name_attribute: "cn",
       mail_attribute: "mail",
       user: "admin",

--- a/server/test/ldap/Client.test.ts
+++ b/server/test/ldap/Client.test.ts
@@ -31,15 +31,60 @@ describe("test authelia ldap client", function () {
     const ldapClient = new LdapClientStub();
 
     factory.createStub.returns(ldapClient);
-    ldapClient.searchAsyncStub.returns(BluebirdPromise.resolve([
-      "group1"
-    ]));
+    ldapClient.searchAsyncStub.returns(BluebirdPromise.resolve([{
+      cn: "group1"
+    }]));
     const client = new Client(ADMIN_USER_DN, ADMIN_PASSWORD, options, factory, Dovehash, Winston);
 
     return client.searchGroups("user1")
       .then(function () {
         Assert.equal(ldapClient.searchAsyncStub.getCall(0).args[1].filter,
           "member=cn=user1,ou=users,dc=example,dc=com");
+      });
+  });
+
+  it("should replace {dn} by user DN when searching for groups in LDAP", function () {
+    const USER_DN = "cn=user1,ou=users,dc=example,dc=com";
+    const options: LdapConfiguration = {
+      url: "ldap://ldap",
+      users_dn: "ou=users,dc=example,dc=com",
+      users_filter: "cn={0}",
+      groups_dn: "ou=groups,dc=example,dc=com",
+      groups_filter: "member={dn}",
+      group_name_attribute: "cn",
+      mail_attribute: "mail",
+      user: "cn=admin,dc=example,dc=com",
+      password: "password"
+    };
+    const factory = new LdapClientFactoryStub();
+    const ldapClient = new LdapClientStub();
+
+    factory.createStub.returns(ldapClient);
+
+    // Retrieve user DN
+    ldapClient.searchAsyncStub.withArgs("ou=users,dc=example,dc=com", {
+      scope: "sub",
+      sizeLimit: 1,
+      attributes: ["dn"],
+      filter: "cn=user1"
+    }).returns(BluebirdPromise.resolve([{
+      dn: USER_DN
+    }]));
+
+    // Retrieve groups
+    ldapClient.searchAsyncStub.withArgs("ou=groups,dc=example,dc=com", {
+      scope: "sub",
+      attributes: ["cn"],
+      filter: "member=" + USER_DN
+    }).returns(BluebirdPromise.resolve([{
+      cn: "group1"
+    }]));
+
+    const client = new Client(ADMIN_USER_DN, ADMIN_PASSWORD, options, factory, Dovehash, Winston);
+
+    return client.searchGroups("user1")
+      .then(function (groups: string[]) {
+        Assert.deepEqual(groups, ["group1"]);
       });
   });
 });


### PR DESCRIPTION
Sometimes, LDAP organization is such that groups membership cannot be computed
with username only. User DN is required to retrieve groups.

e.g. user Joe has a username joe and a cn of Joe Blogs, resulting in a dn of
cn=Joe Blogs,ou=users,dc=example,dc=com which is needed to retrieve groups
but cannot be computed from joe only.

Issue was reported in issue #146