### PR TITLE
Make notifications appear on top instead of inline

### DIFF
--- a/client/src/css/01-main.css
+++ b/client/src/css/01-main.css
@@ -19,9 +19,10 @@ body {
 /* notifications */
 .notification {
   padding: 10px;
-  margin: 10px 0px;
+  margin: 15px 0px;
   border-radius: 6px;
   display: none;
+  position: absolute;
 }
 .notification img {
   width: 24px;

--- a/server/src/views/firstfactor.pug
+++ b/server/src/views/firstfactor.pug
@@ -7,9 +7,9 @@ block form-header
   h1 Sign in
 
 block content
+  div(class="notification")
   img(class="header-img" src="/img/user.png" alt="user profile")
   p Enter your credentials to sign in
-  div(class="notification")
   form(class="form-signin")
     div(class="form-inputs")
       input(type="text" class="form-control" id="username" placeholder="Username" required autofocus)

--- a/server/src/views/password-reset-form.pug
+++ b/server/src/views/password-reset-form.pug
@@ -7,9 +7,9 @@ block form-header
   h1 Reset password
 
 block content
+  div(class="notification")
   img(class="header-img" src="/img/password.png" alt="password")
   p Set your new password and confirm it.
-  div(class="notification")
   form(class="form-signin")
     div(class="form-inputs")
       input(class="form-control" type="password" name="password1" id="password1" placeholder="New password" required="required")

--- a/server/src/views/password-reset-request.pug
+++ b/server/src/views/password-reset-request.pug
@@ -7,10 +7,10 @@ block form-header
   h1 Reset password
 
 block content
+  div(class="notification")
   div
     img(class="header-img" src="/img/password.png" alt="password")
     p After giving your username, you will receive an email to change your password.
-  div(class="notification")
   form(class="form-signin")
     div(class="form-inputs")
       input(type="text" class="form-control" name="username" id="username" placeholder="Your username" required="required")

--- a/server/src/views/secondfactor.pug
+++ b/server/src/views/secondfactor.pug
@@ -7,16 +7,16 @@ block form-header
   h1 Sign in
 
 block content
-  div 
+  div
+    div(class="notification notification-totp")
     h3 Hi <b>#{username}</b>
   div(class="row")
     div(class="u2f-token")
       img(src="/img/pendrive.png", alt="security key")
-    p 
+    p
       | Please, touch your <a href="https://www.yubico.com/products/yubikey-hardware/fido-u2f-security-key/">security key</a><br/>
       b Or<br/>
       | Get a one-time password
-    div(class="notification notification-totp")
     form(class="form-signin totp")
       div(class="form-inputs")
         input(type="text" autocomplete="off" class="form-control" id="token" placeholder="Token" required autofocus)
@@ -25,7 +25,7 @@ block content
         div Need to register?
         div
           a(href=u2f_identity_start_endpoint, class="link register-u2f", data-toggle="tooltip", title="A security key is required to register.") Security key
-          |  | 
+          |  |
           a(href=totp_identity_start_endpoint, class="link register-totp") Google Authenticator
           span(class="clearfix")
   script(src="/js/u2f-api.js", type="text/javascript")

--- a/server/src/views/secondfactor.pug
+++ b/server/src/views/secondfactor.pug
@@ -25,7 +25,7 @@ block content
         div Need to register?
         div
           a(href=u2f_identity_start_endpoint, class="link register-u2f", data-toggle="tooltip", title="A security key is required to register.") Security key
-          |  |
+          |  | 
           a(href=totp_identity_start_endpoint, class="link register-totp") Google Authenticator
           span(class="clearfix")
   script(src="/js/u2f-api.js", type="text/javascript")


### PR DESCRIPTION
Currently notifications reflow the document which causes the interface
to jump twice which can be frustrating if you're trying to click
something.

This change makes the notification appear at the top of the form as
such:

![image](https://user-images.githubusercontent.com/208440/42992422-650185fc-8c00-11e8-825a-584b7b384762.png)

@clems4ever do you agree with this? If not feel free to discard this PR.