### PR TITLE
Add ability to search for groups using {uid}

### DIFF
--- a/config.template.yml
+++ b/config.template.yml
@@ -61,6 +61,7 @@ authentication_backend:
     # The groups filter used for retrieving groups of a given user.
     # {0} is a matcher replaced by username.
     # {dn} is a matcher replaced by user DN.
+    # {uid} is a matcher replaced by user uid.
     # 'member={dn}' by default.
     groups_filter: (&(member={dn})(objectclass=groupOfNames))
 

--- a/example/kube/authelia/configs/config.yml
+++ b/example/kube/authelia/configs/config.yml
@@ -54,6 +54,7 @@ authentication_backend:
     # The groups filter used for retrieving groups of a given user.
     # {0} is a matcher replaced by username.
     # {dn} is a matcher replaced by user DN.
+    # {uid} is a matcher replaced by user uid.
     # 'member={dn}' by default.
     groups_filter: (&(member={dn})(objectclass=groupOfNames))
   


### PR DESCRIPTION
On some LDAP servers, the `uid` attribute is more like a guid, while the
username exists instead in a dedicated field, like `username`. This
means the `uid` is not necessarily equal to `username`.

This is allows referencing using the `uid` to search for groups in the same
way as `dn` so that one can explicitly match the `memberuid` to the `uid` for
the user without the assumptions that come with using `{0}`.

I have run unit tests, but need to verify integration tests pass as well.

This is also my first time working with TypeScript, so let me know if anything I've done is weird. I'm happy to make updates.