### PR TITLE
Fix attaching User/Groups headers for bypass strategy

### DIFF
--- a/server/src/lib/routes/verify/GetSessionCookie.ts
+++ b/server/src/lib/routes/verify/GetSessionCookie.ts
@@ -36,8 +36,6 @@ export default async function (req: Express.Request, res: Express.Response,
   const authorizationLevel = CheckAuthorizations(vars.authorizer, d.domain, d.path, username, groups, req.ip,
     authSession.authentication_level);
 
-  if (authorizationLevel > AuthorizationLevel.BYPASS) {
-    CheckInactivity(req, authSession, vars.config, vars.logger);
-    setUserAndGroupsHeaders(res, username, groups);
-  }
+  CheckInactivity(req, authSession, vars.config, vars.logger);
+  setUserAndGroupsHeaders(res, username, groups);
 }


### PR DESCRIPTION
This change includes attaching the following headers when an authenticated session exists while using the bypass strategy:

- Remote-User
- Remote-Groups