### PR TITLE
Add ability to set timezone for Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.9.4
 
 WORKDIR /usr/app
 
-RUN apk --no-cache add ca-certificates wget
+RUN apk --no-cache add ca-certificates tzdata wget
 
 # Install the libc required by the password hashing compiled with CGO.
 RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub

--- a/docs/deployment-production.md
+++ b/docs/deployment-production.md
@@ -29,7 +29,7 @@ the root of the repo.
 
 ### Deploy With Docker
 
-    docker run -v /path/to/your/config.yml:/etc/authelia/config.yml clems4ever/authelia
+    docker run -v /path/to/your/config.yml:/etc/authelia/config.yml -e TZ=Europe/Paris clems4ever/authelia
 
 
 ## On top of Kubernetes


### PR DESCRIPTION
This change provides the ability to specify a [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) with the `TZ` variable, e.g: `TZ=America/New_York` this will allow end users to select what the "correct" date/time is for their docker instance of Authelia.