### PR TITLE
Add "{CRYPT}" detail to deployment-dev

### DIFF
--- a/docs/deployment-dev.md
+++ b/docs/deployment-dev.md
@@ -100,7 +100,10 @@ The content of this file is as follows:
 
 The password is hashed and salted as it is in LDAP servers with salted SHA-512. Here is a one-liner to generate such hashed password:
 
-    npm run hash-password mypassword
+    $ npm run hash-password mypassword
+    $6$rounds=50000$BpLnfgDsc2WD8F2q$PumMwig8O0uIe9SgneL8Cm1FvUniOzpqBrH.uQE3aZR4K1dHsQldu5gEjJZsXcO./v3itfz6CXTDTJgeh5e8t.
+
+Copy this newly hashed password into your `users_database.yml` file, prefixed with `{CRYPT}` as shown in the example file above.
 
 Once the file is created, edit the configuration file with the following
 block (as used in [config.yml](../test/suites/basic/config.yml)):


### PR DESCRIPTION
Lost a couple hours to this subtle detail of the `users_database.yml` format. I was missing the `{CRYPT}` at the beginning of the hashed password line. 

Alternatively, the `hash-password` tool could prepend this automatically, but I'm pretty new to Authelia, and so I thought a README edit was better first PR 😜 