### PR TITLE
[Docker] Treat non-200 responses as an error and retry up to 3 times

### DIFF
--- a/cmd/authelia-scripts/docker.go
+++ b/cmd/authelia-scripts/docker.go
@@ -48,10 +48,10 @@ func (d *Docker) Manifest(tag, amd64tag, arm32v7tag, arm64v8tag string) error {
 
 // CleanTag remove a tag from dockerhub.
 func (d *Docker) CleanTag(tag string) error {
-	return CommandWithStdout("curl", "-s", "-o", "/dev/null", "-u", "$DOCKER_USERNAME:$DOCKER_PASSWORD", "-X", "DELETE", "https://cloud.docker.com/v2/repositories/"+DockerImageName+"/tags/"+tag+"/").Run()
+	return CommandWithStdout("curl", "-fs", "--retry 3", "-o", "/dev/null", "-u", "$DOCKER_USERNAME:$DOCKER_PASSWORD", "-X", "DELETE", "https://cloud.docker.com/v2/repositories/"+DockerImageName+"/tags/"+tag+"/").Run()
 }
 
 // PublishReadme push README.md to dockerhub.
 func (d *Docker) PublishReadme() error {
-	return CommandWithStdout("bash", "-c", `jq -n --arg msg "$(<README.md)" '{"registry":"registry-1.docker.io","full_description": $msg }' | curl -s -o /dev/null -u $DOCKER_USERNAME:$DOCKER_PASSWORD -X "PATCH" -H "Content-Type: application/json" -d @- https://cloud.docker.com/v2/repositories/clems4ever/authelia/`).Run()
+	return CommandWithStdout("bash", "-c", `jq -n --arg msg "$(<README.md)" '{"registry":"registry-1.docker.io","full_description": $msg }' | curl -fs --retry 3 -o /dev/null -u $DOCKER_USERNAME:$DOCKER_PASSWORD -X "PATCH" -H "Content-Type: application/json" -d @- https://cloud.docker.com/v2/repositories/clems4ever/authelia/`).Run()
 }


### PR DESCRIPTION
As per the description, during the publishing phase if the curl to remove tags or publish the README fails due to a transient error this will not result in the intended outcome, the change treats non-200 responses as a failure and will retry up to three times.