### PR TITLE
Embed commit hash and tag in Authelia binary.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Release Notes - Version 4.0.0
 * Introduction of a "migrate" command to authelia-scripts to help migrating from v3 to v4.
 * Authelia is built and available on Dockerhub in 3 flavors: amd64, arm32v7 and arm64v8.
 * Introduction of suites in Go.
+* Add support of LDAP over TLS.
+* Publish Authelia as self-sufficient archives.
+* Remove the need of putting weird characters /%23/ in the redirection URL to portal.
+* Publish multiple docker tags per version (one for major, minor and patch)
+* Add `host` configuration to restring binding to local interface 127.0.0.1.
+* Add `google_analytics` configuration option to provide a tracking ID for admins to track the use of the portal thanks to a GA dashboard.
 
 Release Notes - Version 3.16.3
 ------------------------------

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -3,6 +3,9 @@
 # =======================================
 FROM arm32v7/golang:1.13-alpine AS builder-backend
 
+ARG BUILD_TAG
+ARG BUILD_COMMIT
+
 # qemu binary, gcc and musl-dev are required for building go-sqlite3
 COPY ./qemu-arm-static /usr/bin/qemu-arm-static
 RUN apk --no-cache add gcc musl-dev
@@ -16,6 +19,13 @@ RUN go mod download
 
 COPY cmd cmd
 COPY internal internal
+
+# Set the build version and time
+RUN echo "Write tag ${BUILD_TAG} and commit ${BUILD_COMMIT} in binary." && \
+    BUILD_TIME=`date +"%Y-%m-%d %T"` && \
+    sed -i "s/__BUILD_TAG__/${BUILD_TAG}/" cmd/authelia/constants.go && \
+    sed -i "s/__BUILD_COMMIT__/${BUILD_COMMIT}/" cmd/authelia/constants.go && \
+    sed -i "s/__BUILD_TIME__/${BUILD_TIME}/" cmd/authelia/constants.go
 
 # CGO_ENABLED=1 is mandatory for building go-sqlite3
 RUN cd cmd/authelia && GOOS=linux GOARCH=arm CGO_ENABLED=1 go build -tags netgo -ldflags '-w' -o authelia
@@ -52,4 +62,4 @@ EXPOSE 9091
 VOLUME /etc/authelia
 VOLUME /var/lib/authelia
 
-CMD ["./authelia", "-config", "/etc/authelia/configuration.yml"]
+CMD ["./authelia", "--config", "/etc/authelia/configuration.yml"]

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -3,6 +3,9 @@
 # =======================================
 FROM arm64v8/golang:1.13-alpine AS builder-backend
 
+ARG BUILD_TAG
+ARG BUILD_COMMIT
+
 # qemu binary, gcc and musl-dev are required for building go-sqlite3
 COPY ./qemu-aarch64-static /usr/bin/qemu-aarch64-static
 RUN apk --no-cache add gcc musl-dev
@@ -16,6 +19,13 @@ RUN go mod download
 
 COPY cmd cmd
 COPY internal internal
+
+# Set the build version and time
+RUN echo "Write tag ${BUILD_TAG} and commit ${BUILD_COMMIT} in binary." && \
+    BUILD_TIME=`date +"%Y-%m-%d %T"` && \
+    sed -i "s/__BUILD_TAG__/${BUILD_TAG}/" cmd/authelia/constants.go && \
+    sed -i "s/__BUILD_COMMIT__/${BUILD_COMMIT}/" cmd/authelia/constants.go && \
+    sed -i "s/__BUILD_TIME__/${BUILD_TIME}/" cmd/authelia/constants.go
 
 # CGO_ENABLED=1 is mandatory for building go-sqlite3
 RUN cd cmd/authelia && GOOS=linux GOARCH=arm64 CGO_ENABLED=1 go build -tags netgo -ldflags '-w' -o authelia
@@ -52,4 +62,4 @@ EXPOSE 9091
 VOLUME /etc/authelia
 VOLUME /var/lib/authelia
 
-CMD ["./authelia", "-config", "/etc/authelia/configuration.yml"]
+CMD ["./authelia", "--config", "/etc/authelia/configuration.yml"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ providing 2-factor authentication and single sign-on (SSO) for your
 applications via a web portal.
 It acts as a companion of reverse proxies like [nginx] or [Traefik] by handling forwarded authentication and authorization requests.
 
-    BREAKING NEWS: Authelia v4 stable release is coming soon! The new version is written in Go for reliability, performance and security improvements. A docker image is currently available in alpha version on dockerhub.
+    BREAKING NEWS: Authelia v4 has been released!
     Please read BREAKING.md if you want to migrate from v3 to v4. Otherwise, start fresh in v4 and enjoy!
 
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -9,6 +9,7 @@ fi
 
 export USER_ID=$(id -u)
 export GROUP_ID=$(id -g)
+export CI=false
 
 
 echo "[BOOTSTRAP] Checking if Go is installed..."

--- a/cmd/authelia-scripts/cmd_serve.go
+++ b/cmd/authelia-scripts/cmd_serve.go
@@ -11,7 +11,7 @@ import (
 // ServeCmd serve authelia with the provided configuration
 func ServeCmd(cobraCmd *cobra.Command, args []string) {
 	log.Infof("Running Authelia with config %s...", args[0])
-	cmd := utils.CommandWithStdout(OutputDir+"/authelia", "-config", args[0])
+	cmd := utils.CommandWithStdout(OutputDir+"/authelia", "--config", args[0])
 	cmd.Env = append(os.Environ(), "PUBLIC_DIR=dist/public_html")
 	utils.RunCommandUntilCtrlC(cmd)
 }

--- a/cmd/authelia-scripts/docker.go
+++ b/cmd/authelia-scripts/docker.go
@@ -8,8 +8,10 @@ import (
 type Docker struct{}
 
 // Build build a docker image
-func (d *Docker) Build(tag, dockerfile, target string) error {
-	return utils.CommandWithStdout("docker", "build", "-t", tag, "-f", dockerfile, target).Run()
+func (d *Docker) Build(tag, dockerfile, target, gitTag, gitCommit string) error {
+	return utils.CommandWithStdout(
+		"docker", "build", "-t", tag, "-f", dockerfile, "--build-arg",
+		"BUILD_TAG="+gitTag, "--build-arg", "BUILD_COMMIT="+gitCommit, target).Run()
 }
 
 // Tag tag a docker image.

--- a/cmd/authelia/constants.go
+++ b/cmd/authelia/constants.go
@@ -1,0 +1,5 @@
+package main
+
+var BuildTag = "__BUILD_TAG__"
+var BuildCommit = "__BUILD_COMMIT__"
+var BuildTime = "__BUILD_TIME__"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,5 +8,5 @@ repository. All the details are documented there.
 When running **Authelia**, you can specify your configuration file by passing
 the file path as the first argument of **Authelia**.
 
-    $ authelia -config config.custom.yml
+    $ authelia --config config.custom.yml
 

--- a/docs/deployment-dev.md
+++ b/docs/deployment-dev.md
@@ -27,7 +27,7 @@ either by pulling the Docker image or building distributable version.
 ## Build and deploy the distributable version
 
     $ authelia-scripts build
-    $ PUBLIC_DIR=./dist/public_html ./dist/authelia -config /path/to/your/config.yml
+    $ PUBLIC_DIR=./dist/public_html ./dist/authelia --config /path/to/your/config.yml
 
 ## Deploy with Docker
 

--- a/docs/deployment-production.md
+++ b/docs/deployment-production.md
@@ -32,11 +32,11 @@ the root of the repo.
 
     # Build it if not done already
     $ authelia-scripts build
-    $ PUBLIC_DIR=./dist/public_html authelia -config /path/to/your/config.yml
+    $ PUBLIC_DIR=./dist/public_html authelia --config /path/to/your/config.yml
 
 ### Deploy With Docker
 
-    $ docker run -v /path/to/your/config.yml:/etc/authelia/config.yml -e TZ=Europe/Paris clems4ever/$ $ authelia -config /etc/authelia/config.yml
+    $ docker run -v /path/to/your/config.yml:/etc/authelia/config.yml -e TZ=Europe/Paris clems4ever/$ $ authelia --config /etc/authelia/config.yml
 
 
 ## On top of Kubernetes

--- a/example/compose/authelia/docker-compose.backend.yml
+++ b/example/compose/authelia/docker-compose.backend.yml
@@ -15,6 +15,7 @@ services:
       - "${GOPATH}:/go"
     environment:
       - ENVIRONMENT=dev
+      - CI=${CI}
     networks:
       authelianet:
         ipv4_address: 192.168.240.50

--- a/example/compose/authelia/resources/entrypoint.sh
+++ b/example/compose/authelia/resources/entrypoint.sh
@@ -2,10 +2,17 @@
 
 set -x
 
-go get github.com/cespare/reflex
+if [ "$CI" == "true" ];
+then
+    echo "Use static version of Authelia"
+    /resources/run.sh
+else
+    echo "Use hot reloaded version of Authelia"
+    go get github.com/cespare/reflex
 
-# Sleep 10 seconds to wait the end of npm install updating web directory
-# and making reflex reload multiple times.
-sleep 10
+    # Sleep 10 seconds to wait the end of npm install updating web directory
+    # and making reflex reload multiple times.
+    sleep 10
 
-reflex -c /resources/reflex.conf
+    reflex -c /resources/reflex.conf
+fi

--- a/example/compose/authelia/resources/run.sh
+++ b/example/compose/authelia/resources/run.sh
@@ -3,10 +3,10 @@
 set -e
 
 # Build the binary
-go build -o /tmp/authelia/authelia-tmp cmd/authelia/main.go
+go build -o /tmp/authelia/authelia-tmp cmd/authelia/*.go
 
 while true;
 do
-    /tmp/authelia/authelia-tmp -config /etc/authelia/configuration.yml
+    /tmp/authelia/authelia-tmp --config /etc/authelia/configuration.yml
     sleep 10
 done

--- a/internal/configuration/validator/authentication.go
+++ b/internal/configuration/validator/authentication.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/clems4ever/authelia/internal/configuration/schema"
 )
@@ -66,8 +67,16 @@ func validateLdapAuthenticationBackend(configuration *schema.LDAPAuthenticationB
 		configuration.UsersFilter = "(cn={0})"
 	}
 
+	if !strings.HasPrefix(configuration.UsersFilter, "(") || !strings.HasSuffix(configuration.UsersFilter, ")") {
+		validator.Push(errors.New("The users filter should contain enclosing parenthesis. For instance cn={0} should be (cn={0})"))
+	}
+
 	if configuration.GroupsFilter == "" {
 		configuration.GroupsFilter = "(member={dn})"
+	}
+
+	if !strings.HasPrefix(configuration.GroupsFilter, "(") || !strings.HasSuffix(configuration.GroupsFilter, ")") {
+		validator.Push(errors.New("The groups filter should contain enclosing parenthesis. For instance cn={0} should be (cn={0})"))
 	}
 
 	if configuration.GroupNameAttribute == "" {

--- a/internal/configuration/validator/authentication_test.go
+++ b/internal/configuration/validator/authentication_test.go
@@ -120,6 +120,20 @@ func (suite *LdapAuthenticationBackendSuite) TestShouldSetDefaultMailAttribute()
 	assert.Equal(suite.T(), "mail", suite.configuration.Ldap.MailAttribute)
 }
 
+func (suite *LdapAuthenticationBackendSuite) TestShouldRaiseWhenUsersFilterDoesNotContainEnclosingParenthesis() {
+	suite.configuration.Ldap.UsersFilter = "cn={0}"
+	ValidateAuthenticationBackend(&suite.configuration, suite.validator)
+	assert.Len(suite.T(), suite.validator.Errors(), 1)
+	assert.EqualError(suite.T(), suite.validator.Errors()[0], "The users filter should contain enclosing parenthesis. For instance cn={0} should be (cn={0})")
+}
+
+func (suite *LdapAuthenticationBackendSuite) TestShouldRaiseWhenGroupsFilterDoesNotContainEnclosingParenthesis() {
+	suite.configuration.Ldap.UsersFilter = "cn={0}"
+	ValidateAuthenticationBackend(&suite.configuration, suite.validator)
+	assert.Len(suite.T(), suite.validator.Errors(), 1)
+	assert.EqualError(suite.T(), suite.validator.Errors()[0], "The users filter should contain enclosing parenthesis. For instance cn={0} should be (cn={0})")
+}
+
 func (suite *LdapAuthenticationBackendSuite) TestShouldAdaptLDAPURL() {
 	assert.Equal(suite.T(), "", validateLdapURL("127.0.0.1", suite.validator))
 	require.Len(suite.T(), suite.validator.Errors(), 1)


### PR DESCRIPTION
In order to easily check where a given binary comes from, we embed information about the commit hash and the release tag in the binary.

Also add a configuration check for missing enclosing parenthesis in LDAP filters.