### PR TITLE
Read X-Real-Ip as the remote IP provided by the proxy.

### DIFF
--- a/internal/middlewares/authelia_context.go
+++ b/internal/middlewares/authelia_context.go
@@ -153,12 +153,17 @@ func (c *AutheliaCtx) SetJSONBody(value interface{}) error {
 
 // RemoteIP return the remote IP taking X-Forwarded-For header into account if provided.
 func (c *AutheliaCtx) RemoteIP() net.IP {
+	XRealIP := c.RequestCtx.Request.Header.Peek("X-Real-IP")
+	if XRealIP != nil {
+		return net.ParseIP(string(XRealIP))
+	}
+
 	XForwardedFor := c.RequestCtx.Request.Header.Peek("X-Forwarded-For")
 	if XForwardedFor != nil {
 		ips := strings.Split(string(XForwardedFor), ",")
 
 		if len(ips) > 0 {
-			return net.ParseIP(strings.Trim(ips[0], " "))
+			return net.ParseIP(strings.TrimSpace(ips[0]))
 		}
 	}
 	return c.RequestCtx.RemoteIP()

--- a/internal/middlewares/authelia_context_test.go
+++ b/internal/middlewares/authelia_context_test.go
@@ -33,3 +33,17 @@ func TestShouldCallNextWithAutheliaCtx(t *testing.T) {
 
 	assert.True(t, nextCalled)
 }
+
+func TestShouldExtractXRealIPAsRemoteIP(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	autheliaCtx := middlewares.AutheliaCtx{
+		RequestCtx: ctx,
+	}
+	assert.Equal(t, "0.0.0.0", autheliaCtx.RemoteIP().String())
+
+	ctx.Request.Header.Add("X-Forwarded-For", "10.0.0.1 , 192.168.0.1, 127.0.0.1")
+	assert.Equal(t, "10.0.0.1", autheliaCtx.RemoteIP().String())
+
+	ctx.Request.Header.Add("X-Real-Ip", "10.2.0.1")
+	assert.Equal(t, "10.2.0.1", autheliaCtx.RemoteIP().String())
+}


### PR DESCRIPTION
Authelia needs to know with what IP was the request originating in
order to apply network based ACL rules. Authelia already supported
X-Forwarded-For but X-Real-IP is another way to define it. It takes
precedence over X-Forwarded-For.